### PR TITLE
Fix ClassNotFoundException when triggering debugger actions

### DIFF
--- a/src/main/java/com/runtime/pivot/plugin/utils/ActionExecutorUtil.java
+++ b/src/main/java/com/runtime/pivot/plugin/utils/ActionExecutorUtil.java
@@ -12,7 +12,17 @@ public class ActionExecutorUtil {
     public static final String SCRIPT = "script" ;
     public static final String RETURN_OBJECT = "returnObject" ;
     private static final String EXECUTE_EXPRESSION =
-            "java.lang.Class<?> actionExecutorClass = java.lang.ClassLoader.getSystemClassLoader().loadClass(\"com.runtime.pivot.agent.ActionExecutor\");\n" +
+            "java.lang.Class<?> actionExecutorClass = null;\n" +
+            "java.lang.ClassLoader contextClassLoader = java.lang.Thread.currentThread().getContextClassLoader();\n" +
+            "if (contextClassLoader != null) {\n" +
+            "    try {\n" +
+            "        actionExecutorClass = contextClassLoader.loadClass(\"com.runtime.pivot.agent.ActionExecutor\");\n" +
+            "    } catch (java.lang.ClassNotFoundException ignore) {\n" +
+            "    }\n" +
+            "}\n" +
+            "if (actionExecutorClass == null) {\n" +
+            "    actionExecutorClass = java.lang.ClassLoader.getSystemClassLoader().loadClass(\"com.runtime.pivot.agent.ActionExecutor\");\n" +
+            "}\n" +
             "java.lang.reflect.Method method = actionExecutorClass.getMethod(\"execute\",String.class,Object[].class);\n" +
             "Object "+RETURN_OBJECT+" = method.invoke(null,\"{"+ACTION_TYPE+"}\",new Object[]{{"+ARGS+"}});\n" +
             "{"+SCRIPT+"};";


### PR DESCRIPTION
### Motivation
- Fix a ClassNotFoundException that occurs when runtime expressions try to load `com.runtime.pivot.agent.ActionExecutor` from the system classloader in environments where the debugger uses a non-system classloader.

### Description
- Change `ActionExecutorUtil` to generate an execution expression that first attempts to load `com.runtime.pivot.agent.ActionExecutor` using the current thread's context classloader and then falls back to `ClassLoader.getSystemClassLoader()` if not found.
- Preserve the existing reflective invocation of `execute(...)` and keep behavior identical when the class is available from the system classloader.
- Modified file: `src/main/java/com/runtime/pivot/plugin/utils/ActionExecutorUtil.java`.

### Testing
- Attempted to run `./gradlew test --no-daemon`, but the Gradle wrapper bootstrap failed to download the Gradle distribution due to an environment proxy returning `HTTP/1.1 403 Forbidden`, so unit tests could not be executed in this environment.
- No automated tests were run successfully because of the wrapper download failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15914e9924833286dbf731a1beac83)