### PR TITLE
README: replace ASCII banner with plugin icon and cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-# runtime-pivot-plugin
+# Runtime-Pivot
 
 <img src="src/main/resources/META-INF/pluginIcon.svg" alt="Runtime Pivot plugin logo" width="128" height="128">
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,7 @@
-```banner https://patorjk.com/software/taag/
-__________ ____ _____________________.___   _____  ___________        __________._______   _______________________
-\______   \    |   \      \__    ___/|   | /     \ \_   _____/        \______   \   \   \ /   /\_____  \__    ___/
- |       _/    |   /   |   \|    |   |   |/  \ /  \ |    __)_   ______ |     ___/   |\   Y   /  /   |   \|    |   
- |    |   \    |  /    |    \    |   |   /    Y    \|        \ /_____/ |    |   |   | \     /  /    |    \    |   
- |____|_  /______/\____|__  /____|   |___\____|__  /_______  /         |____|   |___|  \___/   \_______  /____|   
-        \/                \/                     \/        \/                                          \/         
-```
 <div align="center">
- 
+
+<img src="src/main/resources/META-INF/pluginIcon.svg" alt="Runtime Pivot plugin logo" width="128" height="128">
+
 # runtime-pivot-plugin
 
 [![Downloads](https://img.shields.io/jetbrains/plugin/d/com.runtime.pivot.plugin.svg)](https://plugins.jetbrains.com/plugin/24781-runtime-pivot)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 <div align="center">
 
+# runtime-pivot-plugin
+
 <img src="src/main/resources/META-INF/pluginIcon.svg" alt="Runtime Pivot plugin logo" width="128" height="128">
 
-# runtime-pivot-plugin
+
 
 [![Downloads](https://img.shields.io/jetbrains/plugin/d/com.runtime.pivot.plugin.svg)](https://plugins.jetbrains.com/plugin/24781-runtime-pivot)
 ![Downloads](https://img.shields.io/github/release/wl2027/runtime-pivot.svg)


### PR DESCRIPTION
### Motivation
- Replace the large ASCII art banner in `README.md` with the project plugin icon for a cleaner, more professional repository landing and to reference the icon asset at `src/main/resources/META-INF/pluginIcon.svg`.

### Description
- Updated `README.md` to remove the ASCII banner and centered an `<img>` tag referencing `src/main/resources/META-INF/pluginIcon.svg`, along with minor whitespace/formatting cleanup.

### Testing
- No automated tests were run for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15914e9924833286dbf731a1beac83)